### PR TITLE
Compatibility with React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "postcss-loader": "^0.13.0",
     "postcss-nested": "^1.0.0",
     "postcss-quantity-queries": "^0.4.0",
+    "prop-types": "^15.6.0",
     "raw-loader": "^0.5.1",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",

--- a/src/components/ReactMaterialSelect.jsx
+++ b/src/components/ReactMaterialSelect.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 class ReactMaterialSelect extends Component {

--- a/src/views/Example.jsx
+++ b/src/views/Example.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react'
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 import Highlight from 'react-highlight'
 import ReactMaterialSelect from 'components/ReactMaterialSelect'
 


### PR DESCRIPTION
React 16 is out and PropTypes are no longer available from React package.